### PR TITLE
Dependabot doesnt like the license ref

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 description = "A Bokeh on screen gesture/mouse drag based joystick widget for use in a dashboard with controls"
 readme = "README.md"
-license = {file = "LICENSE.md"}
+# license = {file = "LICENSE.md"}
 keywords = ["bokeh", "joystick"]
 
 classifiers = [


### PR DESCRIPTION
Due to https://github.com/dependabot/dependabot-core/issues/12052 the license file reference must be commented out for dependabot to work.